### PR TITLE
Updated Technology features layout

### DIFF
--- a/che/sass/all.scss
+++ b/che/sass/all.scss
@@ -391,7 +391,11 @@ body.index {
 
 // PAGE - TECHNOLOGY 
 body.technology {
-  .jumbotron {padding-bottom: 0;}
+  .jumbotron {
+    padding-bottom: 0;
+    h1 {margin-top: 30px;}
+    h3 {margin-bottom: 30px;}
+  }
 
   .features {@extend .bg-gray5;
     h2 {margin-bottom: 30px;

--- a/che/stylesheets/all.css
+++ b/che/stylesheets/all.css
@@ -2375,6 +2375,8 @@ body.index .feedback span { color: #5fa8dc; }
   body.index .feedback li:nth-child(3n-2) { clear: left; } }
 
 body.technology .jumbotron { padding-bottom: 0; }
+body.technology .jumbotron h1 { margin-top: 30px; }
+body.technology .jumbotron h3 { margin-bottom: 30px; }
 body.technology .features h2 { margin-bottom: 30px; }
 body.technology .features h2.text-light { margin-bottom: 0; }
 body.technology .features h3, body.technology .features p { margin: 0; }

--- a/che/technology/index.php
+++ b/che/technology/index.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
   include '../includes/variables.php';
 
   // Define page title
@@ -12,10 +12,9 @@
 
 <div class="jumbotron">
   <div class="container-fluid">
+    <img alt="" class="img-responsive" src="../images/hero-technology@2x.png" />
     <h1>Eclipse Che: Development Witchcraft</h1>
     <h3>Eclipse Che is an IDE and developer workspace server that allows anyone to contribute to a project without having to install software. <a href="../getting-started/">Get Started</a></h3>
-
-    <img alt="" class="img-responsive" src="../images/hero-technology@2x.png" />
   </div> <!-- .container-fluid -->
 </div> <!-- .jumbotron -->
 
@@ -24,27 +23,27 @@
     <h2>A new kind of developer workspace.</h2>
 
     <div class="row">
-      <div class="col-sm-6">
+      <div class="col-sm-4">
         <a href="../images/features/img-features-a-new-kind-of-workspace.png" target="_blank"><img alt="" height="300" src="../images/features/img-features-a-new-kind-of-workspace.png" class="img-responsive" /></a>
         <h3>Production Runtimes</h3>
         <p>Eclipse Che works with any single or multi-container runtime. Use an image from DockerHub, your own private registry or one of the included Che images... <a href="../features/">Read More</a></p>
       </div>
 
-      <div class="col-sm-6">
+      <div class="col-sm-4">
         <a href="../images/features/img-features-docker-powered.png" target="_blank"><img alt="" height="333" width="500" src="../images/features/img-features-docker-powered.png" class="img-responsive" /></a>
         <h3>“Dev Mode” your Workspace</h3>
         <p>Workspace runtimes are container-powered, run them in Kubernetes, Docker or OpenShift. Use our all-in-one stacks or author your own. Persist state... <a href="../features/">Read More</a></p>
       </div>
-    </div> <!-- .row -->
 
-    <div class="row">
-      <div class="col-sm-6">
+      <div class="col-sm-4">
         <a href="../images/features/img-features-cloud-ide.png" target="_blank"><img alt="" height="333" width="500" src="../images/features/img-features-cloud-ide.png" class="img-responsive" /></a>
         <h3>Cloud IDE</h3>
         <p>A no-installation browser IDE and IOE accessible from any local or remote device. Thin, fast, and beautiful - it's the IDE our own engineers wanted... <a href="../features/">Read More</a></p>
       </div>
+    </div> <!-- .row -->
 
-      <div class="col-sm-6">
+    <div class="row">
+      <div class="col-sm-4">
         <a href="../images/features/img-features-eclipse-ide.jpg" target="_blank"><img alt="" height="333" width="500" src="../images/features/img-features-eclipse-ide.jpg" class="img-responsive" /></a>
         <h3>Any Desktop IDE</h3>
         <p>Access the workspace file system from your desktop IDE. Using Che remotely? You can mount the Che workspace over SSH. <a href="../features/index.html">Read More</a></p>


### PR DESCRIPTION
Requested changes:

> [Technology] Shrink the featured items/screenshot etc blocks smaller so we can do three across on desktop

> [Technology] Move the headline and opening copy below the hero image