### PR TITLE
The default quicks starts doc should be Che 7 - fixes che/issues/14446

### DIFF
--- a/che/getting-started/download/index.php
+++ b/che/getting-started/download/index.php
@@ -32,7 +32,7 @@
       <img src="../../images/getting-started/icon-local-install.jpg" alt="Eclipse Che | Local Install">
       <h3>Local Install</h3>
       <p>Install Eclipse Che on your computer or a development server.</p>
-      <a href="<?php echo $rootPath; ?>/docs/quick-start.html" class="btn-yellow">Downloads</a> 
+      <a href="<?php echo $rootPath; ?>/docs/che-7/che-quick-starts/" class="btn-yellow">Downloads</a> 
     </div>
 
     <!--<div class="col-md-4">

--- a/che/getting-started/index.php
+++ b/che/getting-started/index.php
@@ -33,7 +33,7 @@
       <img src="../images/getting-started/icon-local-install.jpg" alt="Eclipse Che | Local Install">
       <h3>Download</h3>
       <p>Install anywhere on Kubernetes, OpenShift or Docker.</p>
-      <a href="<?php echo $rootPath; ?>/docs/quick-start.html" class="btn-yellow">Download</a> 
+      <a href="<?php echo $rootPath; ?>/docs/che-7/che-quick-starts/" class="btn-yellow">Download</a> 
     </div>
 
   </div> <!-- /.row -->

--- a/che/includes/footer.php
+++ b/che/includes/footer.php
@@ -7,7 +7,7 @@
           <ul>
             <li><a href="<?php echo $rootPath; ?>/getting-started/">Get Started</a></li>
             <li><a href="<?php echo $rootPath; ?>/getting-started/cloud/">SaaS</a></li>
-            <li><a href="<?php echo $rootPath; ?>/docs/quick-start.html" target="_blank">Install</a></li>
+            <li><a href="<?php echo $rootPath; ?>/docs/che-7/che-quick-starts/" target="_blank">Install</a></li>
             <li><a href="<?php echo $rootPath; ?>/docs/" target="_blank">Docs</a></li>
             <li><a href="<?php echo $rootPath; ?>/extend/codenvy">Commercial Support</a></li>
           </ul>

--- a/che/index.php
+++ b/che/index.php
@@ -30,7 +30,7 @@
       <div class="col-md-6">
         <h3>Local Install</h3>
         <p>Install Eclipse Che on localhost or shared K8S cluster.</p>
-        <a href="<?php echo $rootPath; ?>/docs/quick-start.html" class="btn-yellow">Download</a>
+        <a href="<?php echo $rootPath; ?>/docs/che-7/quick-start.html" class="btn-yellow">Download</a>
 
       </div>
 

--- a/che/index.php
+++ b/che/index.php
@@ -30,7 +30,7 @@
       <div class="col-md-6">
         <h3>Local Install</h3>
         <p>Install Eclipse Che on localhost or shared K8S cluster.</p>
-        <a href="<?php echo $rootPath; ?>/docs/che-7/quick-start.html" class="btn-yellow">Download</a>
+        <a href="<?php echo $rootPath; ?>/docs/che-7/che-quick-starts/" class="btn-yellow">Download</a>
 
       </div>
 


### PR DESCRIPTION
Point Download link to https://www.eclipse.org/che/docs/che-7/che-quick-starts.html

Signed-off-by: Fabrice Flore-Thébault <ffloreth@redhat.com>