### PR TITLE
update devfile now that che.openshift.io has been updated to Che7 GA

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,9 +1,7 @@
 # version that works on che.openshift.io
-
-
-specVersion: 0.0.1
-
-name: che-website
+apiVersion: 1.0.0
+metadata:
+   generateName: che-website-
 
 projects:
   - source:


### PR DESCRIPTION
According to the mail from lukas this summer.

> Hi all,
> 
> This change affects ALL existing devfiles but we hope it is for the better.
> 
> In order to align the devfile format with Kubernetes conventions more 
> (and to open the door for devfile possibly becoming a CRD in the 
> future), we're making the following simple yet important changes:
> 
> * 'specVersion' attribute is being renamed to 'apiVersion'
> * 'name' attribute is being moved under a new 'metadata' key
> 
> So the old devfile starting with the usual snippet:
> 
> specVersion: 0.0.1
> name: acme-devfile
> ...
> 
> will have to change to:
> 
> apiVersion: 0.0.1
> metadata:
>    name: acme-devfile