### PR TITLE
chore(Jenkinsfile): Provide a Jenkinsfile for the ci.eclipse.org

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,88 @@
+pipeline {
+ 
+  agent {
+    kubernetes {
+      label 'che-website-pod'
+      yaml """
+apiVersion: v1
+metadata:
+  labels:
+    run: che-website-pod
+  name: che-website-pod
+spec:
+  containers:
+    - name: jnlp
+      volumeMounts:
+      - mountPath: /home/jenkins/.ssh
+        name: volume-known-hosts
+      env:
+      - name: "HOME"
+        value: "/home/jenkins/agent"
+  volumes:
+  - configMap:
+      name: known-hosts
+    name: volume-known-hosts
+"""
+    }
+  }
+ 
+  environment {
+    PROJECT_NAME = "che"
+    PROJECT_BOT_NAME = "CHE Bot"
+  }
+ 
+  triggers { pollSCM('H/10 * * * *') 
+ 
+ }
+ 
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '5'))
+    checkoutToSubdirectory('che-website')
+  }
+ 
+  stages {
+    stage('Checkout www repo') {
+      steps {
+       container('jnlp') {
+        dir('www') {
+            sshagent(['git.eclipse.org-bot-ssh']) {
+                sh '''
+                    GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no" git clone ssh://genie.${PROJECT_NAME}@git.eclipse.org:29418/www.eclipse.org/${PROJECT_NAME}.git .
+                    git checkout master
+                '''
+            }
+        }
+       }
+      }
+    }
+    stage('Push to $env.BRANCH_NAME branch') {
+      when {
+        branch 'master'
+      }
+      steps {
+        sh 'ls -la'
+        dir('www') {
+            sshagent(['git.eclipse.org-bot-ssh']) {
+                sh '''
+                cd "${WEBSITE}"
+                cp -Rvf ../che-website/che/* .
+                git add -A
+                if ! git diff --cached --exit-code; then
+                  echo "Changes have been detected, publishing to repo 'www.eclipse.org/${PROJECT_NAME}'"
+                  git config --global user.email "${PROJECT_NAME}-bot@eclipse.org"
+                  git config --global user.name "${PROJECT_BOT_NAME}"
+                  export DOC_COMMIT_MSG=$(git log --oneline --format=%B -n 1 HEAD | tail -1)
+                  git commit -m "[docs] ${DOC_COMMIT_MSG}"
+                  git log --graph --abbrev-commit --date=relative -n 5
+                  git push origin HEAD:${BRANCH_NAME}
+                else
+                  echo "No change have been detected since last build, nothing to publish"
+                fi
+                '''
+            }
+        }
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
For now, update on the website was performed with old eclipse CI
https://ci.eclipse.org/che/job/che-website-mirror

but this instance is gonna be removed and replaced by a new CI instance allowing to use containers

Here is a Jenkinsfile to publish website with new JIRO instance

Change-Id: I7241c3fdfffe0bc5e2b7e5d3c7e75852c7b6fac8
Signed-off-by: Florent Benoit <fbenoit@redhat.com>