### PR TITLE
fix: update twitter logo to x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
 		"format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. ."
 	},
 	"devDependencies": {
-		"@fortawesome/free-brands-svg-icons": "^5.15.4",
-		"@fortawesome/free-solid-svg-icons": "^5.15.4",
+		"@fortawesome/free-brands-svg-icons": "^6.7.2",
+		"@fortawesome/free-solid-svg-icons": "^6.7.2",
 		"@icons-pack/svelte-simple-icons": "https://github.com/icons-pack/svelte-simple-icons.git#v2.2.0",
 		"@sveltejs/adapter-node": "^1.0.0-next.68",
 		"@sveltejs/adapter-static": "^1.0.0-next.28",

--- a/src/lib/footer/PageFooter.svelte
+++ b/src/lib/footer/PageFooter.svelte
@@ -2,7 +2,7 @@
 import FooterCategory from './FooterCategory.svelte'; 
 import FooterCategoryLink from './FooterCategoryLink.svelte';
 import Fa from 'svelte-fa/src/fa.svelte'
-import { faTwitter } from '@fortawesome/free-brands-svg-icons'
+import { faXTwitter } from '@fortawesome/free-brands-svg-icons'
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
 import { faBlog } from '@fortawesome/free-solid-svg-icons'
 import EclipseCheLogo from '../logo/EclipseCheLogo.svelte';
@@ -57,7 +57,7 @@ import { variables } from '$lib/variables';
       <p class="text-gray-500 dark:text-gray-400 text-sm text-center sm:text-left">© 2023 Eclipse Che</p>
       <span class="inline-flex sm:ml-auto sm:mt-0 mt-2 justify-center sm:justify-start">
         <a target="_blank" title="github" rel="noopener noreferrer" href="https://github.com/eclipse/che" class="w-8 h-5 text-gray-500 dark:text-gray-400"><Fa icon={faGithub} /></a>
-        <a target="_blank" title="twitter" rel="noopener noreferrer" href="https://twitter.com/eclipse_che" class="w-8 h-5 text-gray-500 dark:text-gray-400"><Fa icon={faTwitter} /></a>
+        <a target="_blank" title="twitter" rel="noopener noreferrer" href="https://twitter.com/eclipse_che" class="w-8 h-5 text-gray-500 dark:text-gray-400"><Fa icon={faXTwitter} /></a>
         <a target="_blank" title="blog" rel="noopener noreferrer" href="https://che.eclipseprojects.io" class="w-8 h-5 text-gray-500 dark:text-gray-400"><Fa icon={faBlog} /></a>
       </span>
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,24 +50,24 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@fortawesome/fontawesome-common-types@^0.2.36":
-  version "0.2.36"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz#b44e52db3b6b20523e0c57ef8c42d315532cb903"
-  integrity sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==
+"@fortawesome/fontawesome-common-types@6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz#7123d74b0c1e726794aed1184795dbce12186470"
+  integrity sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==
 
-"@fortawesome/free-brands-svg-icons@^5.15.4":
-  version "5.15.4"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.15.4.tgz#ec8a44dd383bcdd58aa7d1c96f38251e6fec9733"
-  integrity sha512-f1witbwycL9cTENJegcmcZRYyawAFbm8+c6IirLmwbbpqz46wyjbQYLuxOc7weXFXfB7QR8/Vd2u5R3q6JYD9g==
+"@fortawesome/free-brands-svg-icons@^6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.7.2.tgz#4ebee8098f31da5446dda81edc344025eb59b27e"
+  integrity sha512-zu0evbcRTgjKfrr77/2XX+bU+kuGfjm0LbajJHVIgBWNIDzrhpRxiCPNT8DW5AdmSsq7Mcf9D1bH0aSeSUSM+Q==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.36"
+    "@fortawesome/fontawesome-common-types" "6.7.2"
 
-"@fortawesome/free-solid-svg-icons@^5.15.4":
-  version "5.15.4"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz#2a68f3fc3ddda12e52645654142b9e4e8fbb6cc5"
-  integrity sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==
+"@fortawesome/free-solid-svg-icons@^6.7.2":
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz#fe25883b5eb8464a82918599950d283c465b57f6"
+  integrity sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==
   dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.36"
+    "@fortawesome/fontawesome-common-types" "6.7.2"
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
Fixes #117. The twitter logo has been updated on https://eclipse.dev/che/.
<img width="159" height="55" alt="Screenshot 2025-10-03 at 12 03 51 AM" src="https://github.com/user-attachments/assets/386e8a86-d438-4f8d-a82c-c26eba660975" />
